### PR TITLE
feat: add IFluidTransfer.canFill() and .canDrain()

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/misc/BucketPickupTransfer.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/misc/BucketPickupTransfer.java
@@ -95,4 +95,13 @@ public class BucketPickupTransfer implements IFluidTransfer {
         return FluidStack.empty();
     }
 
+    @Override
+    public boolean supportsFill(int tank) {
+        return false;
+    }
+
+    @Override
+    public boolean supportsDrain(int tank) {
+        return true;
+    }
 }

--- a/common/src/main/java/com/lowdragmc/lowdraglib/misc/FluidBlockTransfer.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/misc/FluidBlockTransfer.java
@@ -64,4 +64,14 @@ public class FluidBlockTransfer implements IFluidTransfer {
 
         return FluidStack.empty();
     }
+
+    @Override
+    public boolean supportsFill(int tank) {
+        return false;
+    }
+
+    @Override
+    public boolean supportsDrain(int tank) {
+        return true;
+    }
 }

--- a/common/src/main/java/com/lowdragmc/lowdraglib/misc/FluidStorage.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/misc/FluidStorage.java
@@ -120,4 +120,14 @@ public class FluidStorage implements IFluidStorage, IContentChangeAware, ITagSer
         storage.setFluid(fluid.copy());
         return storage;
     }
+
+    @Override
+    public boolean supportsFill(int tank) {
+        return true;
+    }
+
+    @Override
+    public boolean supportsDrain(int tank) {
+        return true;
+    }
 }

--- a/common/src/main/java/com/lowdragmc/lowdraglib/misc/FluidTransferList.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/misc/FluidTransferList.java
@@ -172,4 +172,32 @@ public class FluidTransferList implements IFluidTransfer, ITagSerializable<Compo
             }
         }
     }
+
+    @Override
+    public boolean supportsFill(int tank) {
+        for (IFluidTransfer transfer : transfers) {
+            if (tank >= transfer.getTanks()) {
+                tank -= transfer.getTanks();
+                continue;
+            }
+
+            return transfer.supportsFill(tank);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean supportsDrain(int tank) {
+        for (IFluidTransfer transfer : transfers) {
+            if (tank >= transfer.getTanks()) {
+                tank -= transfer.getTanks();
+                continue;
+            }
+
+            return transfer.supportsDrain(tank);
+        }
+
+        return false;
+    }
 }

--- a/common/src/main/java/com/lowdragmc/lowdraglib/misc/LiquidBlockContainerTransfer.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/misc/LiquidBlockContainerTransfer.java
@@ -70,6 +70,16 @@ public class LiquidBlockContainerTransfer implements IFluidTransfer {
         return 0;
     }
 
+    @Override
+    public boolean supportsFill(int tank) {
+        return true;
+    }
+
+    @Override
+    public boolean supportsDrain(int tank) {
+        return false;
+    }
+
     public static class BlockWrapper implements IFluidTransfer {
 
         protected final BlockState state;
@@ -121,6 +131,16 @@ public class LiquidBlockContainerTransfer implements IFluidTransfer {
                 world.setBlock(blockPos, state, Block.UPDATE_ALL_IMMEDIATE);
             }
             return FluidHelper.getBucket();
+        }
+
+        @Override
+        public boolean supportsFill(int tank) {
+            return true;
+        }
+
+        @Override
+        public boolean supportsDrain(int tank) {
+            return false;
         }
     }
 }

--- a/common/src/main/java/com/lowdragmc/lowdraglib/side/fluid/IFluidTransfer.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/side/fluid/IFluidTransfer.java
@@ -37,10 +37,20 @@ public interface IFluidTransfer {
             return 0;
         }
 
+        @Override
+        public boolean supportsFill(int tank) {
+            return false;
+        }
+
         @NotNull
         @Override
         public FluidStack drain(FluidStack resource, boolean simulate) {
             return FluidStack.empty();
+        }
+
+        @Override
+        public boolean supportsDrain(int tank) {
+            return false;
         }
     };
 
@@ -103,6 +113,19 @@ public interface IFluidTransfer {
     long fill(FluidStack resource, boolean simulate);
 
     /**
+     * Determines whether the specified tank can be inserted into.
+     *
+     * <p>
+     * This does NOT check whether a specific amount or type of fluid can be inserted, just whether the tank
+     * supports insertion at all.
+     * </p>
+     *
+     * @param tank Tank to query for insertion
+     * @return Whether fluid can be filled into the specified tank.
+     */
+    boolean supportsFill(int tank);
+
+    /**
      * Drains fluid out of internal tanks, distribution is left entirely to the IFluidTransfer.
      *
      * @param resource FluidStack representing the Fluid and maximum amount of fluid to be drained.
@@ -112,6 +135,19 @@ public interface IFluidTransfer {
      */
     @Nonnull
     FluidStack drain(FluidStack resource, boolean simulate);
+
+    /**
+     * Determines whether the specified tank can be extracted from.
+     *
+     * <p>
+     * This does NOT check whether a specific amount or type of fluid can be extracted, just whether the tank
+     * supports extraction at all.
+     * </p>
+     *
+     * @param tank Tank to query for extraction
+     * @return Whether fluid can be drained from the specified tank.
+     */
+    boolean supportsDrain(int tank);
 
     /**
      * Drains fluid out of internal tanks, distribution is left entirely to the IFluidTransfer.

--- a/fabric/src/main/java/com/lowdragmc/lowdraglib/side/fluid/fabric/FluidTransferHelperImpl.java
+++ b/fabric/src/main/java/com/lowdragmc/lowdraglib/side/fluid/fabric/FluidTransferHelperImpl.java
@@ -151,6 +151,15 @@ public class FluidTransferHelperImpl {
                 return copied;
             }
 
+            @Override
+            public boolean supportsFill(int tank) {
+                return storage.supportsInsertion();
+            }
+
+            @Override
+            public boolean supportsDrain(int tank) {
+                return storage.supportsExtraction();
+            }
         };
     }
 

--- a/forge/src/main/java/com/lowdragmc/lowdraglib/side/fluid/forge/FluidTransferWrapper.java
+++ b/forge/src/main/java/com/lowdragmc/lowdraglib/side/fluid/forge/FluidTransferWrapper.java
@@ -44,4 +44,16 @@ public record FluidTransferWrapper(@Getter IFluidHandler handler) implements IFl
     public FluidStack drain(FluidStack resource, boolean simulate) {
         return FluidHelperImpl.toFluidStack(handler.drain(FluidHelperImpl.toFluidStack(resource), simulate ? IFluidHandler.FluidAction.SIMULATE : IFluidHandler.FluidAction.EXECUTE));
     }
+
+    @Override
+    public boolean supportsFill(int tank) {
+        // IFluidHandler doesn't support this check natively.
+        return true;
+    }
+
+    @Override
+    public boolean supportsDrain(int tank) {
+        // IFluidHandler doesn't support this check natively.
+        return true;
+    }
 }


### PR DESCRIPTION
This is necessary for GTCEu's Fluid Regulator cover, to determine which slots to keep at a specific amount.