### PR TITLE
Fix MultiblockInfo can't be added to ME Pattern Encoding Terminal.

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/jei/ModularUIRecipeCategory.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/jei/ModularUIRecipeCategory.java
@@ -37,18 +37,21 @@ public abstract class ModularUIRecipeCategory<T extends ModularWrapper<?>> imple
         for (Widget widget : flatVisibleWidgetCollection) {
             if (widget instanceof IRecipeIngredientSlot slot) {
                 var role = mapToRole(slot.getIngredientIO());
+                Position pos = widget.getPosition();
+                IRecipeSlotBuilder slotBuilder;
                 if (widget.getParent() instanceof DraggableScrollableWidgetGroup) {
                     // don't add the JEI widget at all if we have a draggable group, let the draggable widget handle it instead.
                     if (role == null) {
                         builder.addInvisibleIngredients(RecipeIngredientRole.INPUT).addIngredientsUnsafe(slot.getXEIIngredients());
                         builder.addInvisibleIngredients(RecipeIngredientRole.OUTPUT).addIngredientsUnsafe(slot.getXEIIngredients());
+                        builder.addSlotToWidget(RecipeIngredientRole.INPUT, (builder1, recipe, slots) -> {}).addIngredientsUnsafe(slot.getXEIIngredients());
+                        builder.addSlotToWidget(RecipeIngredientRole.OUTPUT, (builder1, recipe, slots) -> {}).addIngredientsUnsafe(slot.getXEIIngredients());
                     } else {
                         builder.addInvisibleIngredients(role).addIngredientsUnsafe(slot.getXEIIngredients());
+                        builder.addSlotToWidget(role, (builder1, recipe, slots) -> {}).addIngredientsUnsafe(slot.getXEIIngredients());
                     }
                     continue;
                 }
-                Position pos = widget.getPosition();
-                IRecipeSlotBuilder slotBuilder;
                 if (role == null) { // both
                     addJEISlot(builder, slot, RecipeIngredientRole.INPUT, pos.x, pos.y);
                     slotBuilder = addJEISlot(builder, slot, RecipeIngredientRole.OUTPUT, pos.x, pos.y);


### PR DESCRIPTION
Fix MultiblockInfo can't be added to ME Pattern Encoding Terminal.

Add the slot to an empty widget to avoid show in the multiblock info page.

https://github.com/user-attachments/assets/7950154f-eb8b-417c-bd79-b4c0f1aaaf9e

