### PR TITLE
Extract item slot and fluid tank clearing into separate methods

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/emi/ModularEmiRecipe.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/emi/ModularEmiRecipe.java
@@ -116,11 +116,9 @@ public abstract class ModularEmiRecipe<T extends Widget> implements EmiRecipe {
                     SlotWidget slotWidget = null;
                     // Clear the LDLib slots & add EMI slots based on them.
                     if (slot instanceof com.lowdragmc.lowdraglib.gui.widget.SlotWidget slotW) {
-                        slotW.setHandlerSlot(IItemTransfer.EMPTY, 0);
-                        slotW.setDrawHoverOverlay(false).setDrawHoverTips(false);
+                        clearSlotWidgetHandler(slotW, 0);
                     } else if (slot instanceof com.lowdragmc.lowdraglib.gui.widget.TankWidget tankW) {
-                        tankW.setFluidTank(IFluidStorage.EMPTY);
-                        tankW.setDrawHoverOverlay(false).setDrawHoverTips(false);
+                        clearTankWidgetHandler(tankW);
                         long capacity = Math.max(1, ingredients.getAmount());
                         slotWidget = new TankWidget(ingredients, w.getPosition().x, w.getPosition().y, w.getSize().width, w.getSize().height, capacity);
                     }
@@ -145,6 +143,16 @@ public abstract class ModularEmiRecipe<T extends Widget> implements EmiRecipe {
         widgets.add(new ModularWrapperWidget(modular, slots));
         slots.forEach(widgets::add);
         widgets.add(new ModularForegroundRenderWidget(modular));
+    }
+
+    public void clearSlotWidgetHandler(com.lowdragmc.lowdraglib.gui.widget.SlotWidget slotW, int slotIndex) {
+        slotW.setHandlerSlot(IItemTransfer.EMPTY, slotIndex);
+        slotW.setDrawHoverOverlay(false).setDrawHoverTips(false);
+    }
+
+    public void clearTankWidgetHandler(com.lowdragmc.lowdraglib.gui.widget.TankWidget tankW) {
+        tankW.setFluidTank(IFluidStorage.EMPTY);
+        tankW.setDrawHoverOverlay(false).setDrawHoverTips(false);
     }
 
     public static ModularWrapper<?> TEMP_CACHE = null;

--- a/common/src/main/java/com/lowdragmc/lowdraglib/rei/ModularDisplay.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/rei/ModularDisplay.java
@@ -125,11 +125,9 @@ public class ModularDisplay<T extends Widget> implements Display {
 
                 // Clear the LDLib slots
                 if (slot instanceof com.lowdragmc.lowdraglib.gui.widget.SlotWidget slotW) {
-                    slotW.setHandlerSlot(IItemTransfer.EMPTY, 0);
-                    slotW.setDrawHoverOverlay(false).setDrawHoverTips(false);
+                    clearSlotWidgetHandler(slotW, 0);
                 } else if (slot instanceof TankWidget tankW) {
-                    tankW.setFluidTank(IFluidStorage.EMPTY);
-                    tankW.setDrawHoverOverlay(false).setDrawHoverTips(false);
+                    clearTankWidgetHandler(tankW);
                 }
                 entryWidget.tooltipProcessor(tooltips -> {
                     if (tooltips.entries().stream().noneMatch(tooltip -> !tooltip.isText() || w.getTooltipTexts().contains(tooltip.getAsText()))) {
@@ -144,6 +142,16 @@ public class ModularDisplay<T extends Widget> implements Display {
         list.add(new ModularForegroundRenderWidget(modular));
 
         return list;
+    }
+
+    public void clearSlotWidgetHandler(com.lowdragmc.lowdraglib.gui.widget.SlotWidget slotW, int slotIndex) {
+        slotW.setHandlerSlot(IItemTransfer.EMPTY, slotIndex);
+        slotW.setDrawHoverOverlay(false).setDrawHoverTips(false);
+    }
+
+    public void clearTankWidgetHandler(TankWidget tankW) {
+        tankW.setFluidTank(IFluidStorage.EMPTY);
+        tankW.setDrawHoverOverlay(false).setDrawHoverTips(false);
     }
 
     @Override


### PR DESCRIPTION
## Description
This PR implements necessary changes to resolve https://github.com/Low-Drag-MC/Multiblocked2/issues/18
With this PR merged, another PR will be opened on MDB2's side to accommodate these changes.

## Motivation
As per my investigation and screret comments, this is probably the optimal way to partially resolve mentioned issue. Any mods dependent on LDLib, which use actual item/fluid handler internally, can override newly created methods to not nuke underlying slot/fluid handlers.

## Approach
The original logic remains the same to not break other mods depending on the current logic. Therefore, this feature is pretty much opt in.