### PR TITLE
Not re-enabling depth testing does in fact cause rendering issues

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/gui/util/DrawerHelper.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/gui/util/DrawerHelper.java
@@ -191,10 +191,8 @@ public class DrawerHelper {
 
         // clear depth buffer,it may cause some rendering issues?
         RenderSystem.clear(GL11.GL_DEPTH_BUFFER_BIT, Minecraft.ON_OSX);
-        RenderSystem.depthMask(false);
         RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
         RenderSystem.enableBlend();
-        RenderSystem.disableDepthTest();
     }
 
     public static List<Component> getItemToolTip(ItemStack itemStack) {


### PR DESCRIPTION
![Greate/Create & Mekanism fucking dying](https://github.com/user-attachments/assets/bed868bf-13b2-413d-b390-8d1b5e606988)
![A closeup of Mekanism's suffering](https://github.com/user-attachments/assets/9c8a0ef4-c2e6-4a2d-bdda-b76dababa29b)
![Create's Item Drain getting fucked](https://github.com/user-attachments/assets/b6d89547-b332-4c69-ba50-a87937c14b81)

Depth testing is pretty crucial for rendering complex things from other mods. Unfortunately, when [`com.lowdragmc.lowdraglib.gui.util.DrawerHelper#drawItemStack`](https://github.com/Low-Drag-MC/LDLib-MultiLoader/blob/3977811a8b53f945df56ef90f8add78bd7cb063e/common/src/main/java/com/lowdragmc/lowdraglib/gui/util/DrawerHelper.java#L174) is called by [`com.lowdragmc.lowdraglib.gui.texture.ItemStackTexture#drawInternal`](https://github.com/Low-Drag-MC/LDLib-MultiLoader/blob/3977811a8b53f945df56ef90f8add78bd7cb063e/common/src/main/java/com/lowdragmc/lowdraglib/gui/texture/ItemStackTexture.java#L61), it gets [enabled](https://github.com/Low-Drag-MC/LDLib-MultiLoader/blob/3977811a8b53f945df56ef90f8add78bd7cb063e/common%2Fsrc%2Fmain%2Fjava%2Fcom%2Flowdragmc%2Flowdraglib%2Fgui%2Futil%2FDrawerHelper.java#L181), then [disabled](https://github.com/Low-Drag-MC/LDLib-MultiLoader/blob/3977811a8b53f945df56ef90f8add78bd7cb063e/common%2Fsrc%2Fmain%2Fjava%2Fcom%2Flowdragmc%2Flowdraglib%2Fgui%2Futil%2FDrawerHelper.java#L197), but never enabled again.

The primary effect of this, is as follows: When a **non-GT** machine recipe category is selected, and a certain amount (not definite, but usually 3 or more) of recipe category icons featuring a GT machine are visible at once in JEI (or another viewer such as EMI), it breaks the rendering of EVERY other itemstack onscreen that is reliant on depth testing. See the images attached above for what i mean by that.