### PR TITLE
fix GUIs not reponding to key presses while hovering stacks

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/gui/widget/SlotWidget.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/gui/widget/SlotWidget.java
@@ -771,16 +771,14 @@ public class SlotWidget extends Widget implements IRecipeIngredientSlot, IConfig
 
         public static boolean mouseClicked(Object ingredient, int button) {
             if (ingredient instanceof EmiStack emiStack) {
-                EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesMouse(button));
-                return true;
+                return EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesMouse(button));
             }
             return false;
         }
 
         public static boolean keyPressed(Object ingredient, int keyCode, int scanCode, int modifiers) {
             if (ingredient instanceof EmiStack emiStack) {
-                EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesKey(keyCode, scanCode));
-                return true;
+                return EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesKey(keyCode, scanCode));
             }
             return false;
         }

--- a/common/src/main/java/com/lowdragmc/lowdraglib/gui/widget/TankWidget.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/gui/widget/TankWidget.java
@@ -731,16 +731,14 @@ public class TankWidget extends Widget implements IRecipeIngredientSlot, IConfig
 
         public static boolean mouseClick(Object ingredient, int button) {
             if (ingredient instanceof EmiStack emiStack) {
-                EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesMouse(button));
-                return true;
+                return EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesMouse(button));
             }
             return false;
         }
 
         public static boolean keyPressed(Object ingredient, int keyCode, int scanCode, int modifiers) {
             if (ingredient instanceof EmiStack emiStack) {
-                EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesKey(keyCode, scanCode));
-                return true;
+                return EmiScreenManager.stackInteraction(new EmiStackInteraction(emiStack), (bind) -> bind.matchesKey(keyCode, scanCode));
             }
             return false;
         }


### PR DESCRIPTION
this PR fixes the EMI integration capturing ANY keys pressed while hovering a stack, not just the EMI hotkeys

sorry for this oversight, have been testing since the first PR but didnt actually saw it as a bug until someone spelled it out for me.