### PR TITLE
Export un-remapped sources jar when publishing and Jitpack support

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -62,9 +62,19 @@ dependencies {
 
 publishing {
     publications {
-        mavenCommon(MavenPublication) {
+        register("mavenCommon", MavenPublication) {
             artifactId = archivesBaseName
-            from components.java
+            // from components.java
+
+            artifact(remapJar) {
+                builtBy remapJar
+                classifier ''
+            }
+
+            artifact(sourcesJar) {
+                builtBy sourcesJar
+                classifier 'sources'
+            }
         }
     }
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -165,9 +165,19 @@ components.java {
 
 publishing {
     publications {
-        mavenFabric(MavenPublication) {
+        register("mavenCommon", MavenPublication) {
             artifactId = archivesBaseName
-            from components.java
+            // from components.java
+
+            artifact(remapJar) {
+                builtBy remapJar
+                classifier ''
+            }
+
+            artifact(sourcesJar) {
+                builtBy sourcesJar
+                classifier 'sources'
+            }
         }
     }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -176,9 +176,19 @@ components.java {
 
 publishing {
     publications {
-        mavenForge(MavenPublication) {
+        register("mavenCommon", MavenPublication) {
             artifactId = archivesBaseName
-            from components.java
+            // from components.java
+
+            artifact(remapJar) {
+                builtBy remapJar
+                classifier ''
+            }
+
+            artifact(sourcesJar) {
+                builtBy sourcesJar
+                classifier 'sources'
+            }
         }
     }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 17.0.16-tem
+  - sdk use java 17.0.16-tem


### PR DESCRIPTION
It's quite annoying not able to view the sources when using other non-loom toolchains, where there's huge amount of red `m_xxxxx`.

This PR changed the published sources jar back to the result of `sourcesJar` instead of remapped `remapSourcesJar`.

And added a jitpack config to make it work. If you don't like it, I can revert the commit.