### PR TITLE
Fix UI rounding error and Crash related to SelectorWidget

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/gui/editor/configurator/NumberConfigurator.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/gui/editor/configurator/NumberConfigurator.java
@@ -98,7 +98,12 @@ public class NumberConfigurator extends ValueConfigurator<Number> {
     }
 
     private void onNumberUpdate(String s) {
-        Number newValue = isDecimal ? Float.parseFloat(s) : Long.parseLong(s);
+        Number newValue;
+        if (isDecimal) {
+            newValue=Double.parseDouble(s);
+        } else {
+            newValue=Long.parseLong(s);
+        }
         if (value instanceof Integer && !value.equals(newValue.intValue())) {
             value = newValue.intValue();
             updateValue();

--- a/common/src/main/java/com/lowdragmc/lowdraglib/gui/widget/SelectorWidget.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/gui/widget/SelectorWidget.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 public class SelectorWidget extends WidgetGroup {
     protected List<SelectableWidgetGroup> selectables;
     @Configurable(name = "ldlib.gui.editor.name.candidates")
-    protected List<String> candidates;
+    protected List<String> candidates = new ArrayList<>();
     @Configurable(name = "ldlib.gui.editor.name.currentValue")
     protected String currentValue;
     @Configurable(name = "ldlib.gui.editor.name.maxCount")
@@ -62,7 +62,7 @@ public class SelectorWidget extends WidgetGroup {
         this.button = new ButtonWidget(0,0, width, height, IGuiTexture.EMPTY, d -> {
             if (d.isRemote) setShow(!isShow);
         });
-        this.candidates = candidates;
+        this.candidates.addAll(candidates);
         this.selectables = new ArrayList<>();
         this.addWidget(button);
         this.addWidget(new ImageWidget(0, 1, width, height - 1, textTexture = new TextTexture("", fontColor).setWidth(width).setType(TextTexture.TextType.ROLL)));
@@ -140,7 +140,10 @@ public class SelectorWidget extends WidgetGroup {
 
     @ConfigSetter(field = "candidates")
     public void setCandidates(List<String> candidates) {
-        this.candidates = candidates;
+        if (this.candidates != candidates) {
+            this.candidates.clear();
+            this.candidates.addAll(candidates);
+        }
         computeLayout();
     }
 


### PR DESCRIPTION
fixes issue #92 
also fixes a crash that i found while testing:

if an immutable list is passed to the constructor of `com.lowdragmc.lowdraglib.gui.widget.SelectorWidget` and then `com.lowdragmc.lowdraglib.syncdata.accessor.CollectionAccessor` tries to modify `SelectorWidget.candidates`, an `UnsupportedOperationException` is thrown because the list is immutable.
This happens when you try to load a project in the ui editor containing a selector widget