### PR TITLE
Refactor VirtualChunk to fix #94

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/utils/virtual/VirtualChunk.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/utils/virtual/VirtualChunk.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import it.unimi.dsi.fastutil.shorts.ShortList;
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.Entity;
@@ -20,6 +21,7 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.ticks.BlackholeTickAccess;
+import net.minecraft.world.ticks.LevelChunkTicks;
 import net.minecraft.world.ticks.TickContainerAccess;
 
 import javax.annotation.Nullable;
@@ -36,33 +38,33 @@ public class VirtualChunk extends LevelChunk {
 	final int x;
 	final int z;
 
-	private final LevelChunkSection[] sections;
-
 	public VirtualChunk(DummyWorld world, int x, int z) {
-		super(world, new ChunkPos(x, z));
+		super(
+            world,
+            new ChunkPos(x, z),
+            UpgradeData.EMPTY,
+            new LevelChunkTicks<>(),
+            new LevelChunkTicks<>(),
+            0L,
+            Util.make(new LevelChunkSection[world.getSectionsCount()], sections -> {
+                for (int i = 0; i < sections.length; i++) {
+                    sections[i] = new VirtualChunkSection(world, new ChunkPos(x, z), i << 4);
+                }
+            }),
+            null,
+            null
+            );
+
 		this.needsLight = true;
 		this.x = x;
 		this.z = z;
-
-		int sectionCount = world.getSectionsCount();
-		this.sections = new LevelChunkSection[sectionCount];
-
-		for (int i = 0; i < sectionCount; i++) {
-			sections[i] = new VirtualChunkSection(this, i << 4);
-		}
-
 	}
 
 	public DummyWorld getDummyWorld() {
 		return (DummyWorld) this.getLevel();
 	}
 
-	@Override
-	public LevelChunkSection[] getSections() {
-		return sections;
-	}
-
-	@Override
+    @Override
 	public ChunkStatus getStatus() {
 		return ChunkStatus.LIGHT;
 	}

--- a/common/src/main/java/com/lowdragmc/lowdraglib/utils/virtual/VirtualChunkSection.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/utils/virtual/VirtualChunkSection.java
@@ -1,7 +1,9 @@
 package com.lowdragmc.lowdraglib.utils.virtual;
 
+import com.lowdragmc.lowdraglib.utils.DummyWorld;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 
@@ -11,27 +13,25 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public class VirtualChunkSection extends LevelChunkSection {
 
-	public VirtualChunk owner;
+    public final DummyWorld dummyWorld;
 
 	public final int xStart;
 	public final int yStart;
 	public final int zStart;
 
-	public VirtualChunkSection(VirtualChunk owner, int yBase) {
-		super(owner.getDummyWorld().registryAccess().registryOrThrow(Registries.BIOME));
-		this.owner = owner;
-		this.xStart = owner.getPos()
-			.getMinBlockX();
-		this.yStart = yBase;
-		this.zStart = owner.getPos()
-			.getMinBlockZ();
-	}
+    public VirtualChunkSection(DummyWorld dummyWorld, ChunkPos chunkPos, int yBase) {
+        super(dummyWorld.registryAccess().registryOrThrow(Registries.BIOME));
+        this.dummyWorld = dummyWorld;
+        this.xStart = chunkPos.getMinBlockX();
+        this.zStart = chunkPos.getMinBlockZ();
+        this.yStart = yBase;
+    }
 
 	@Override
 	public BlockState getBlockState(int x, int y, int z) {
 		// ChunkSection#getBlockState expects local chunk coordinates, so we add to get
 		// back into world coords.
-		return owner.getDummyWorld().getBlockState(x + xStart, y + yStart, z + zStart);
+        return dummyWorld.getBlockState(x + xStart, y + yStart, z + zStart);
 	}
 
 	@Override


### PR DESCRIPTION
Fixed #94 

我不确定为什么 VirtualChunk 里面还有一个 sections，我把它删了，用了父类里，同时改成了可以控制初始 sections 的 super 构造方法（除了 sections 参数，其他都和原来的相同），这样 sections 就不会是 null。

因为 VirtualChunkSection 构造的时候，VirtualChunk 还没 super 完，所以 `this` 不能用，我注意到 VCSection 里面没有用到 VirtualChunk，所以我直接把它和 VC 解耦了，把一些用到的东西（例如 DummyWorld 实例）直接在构造的时候丢进去。

用这个 PR 构建出来的版本确定可以修复上面提到的 L2 和 GTM 不相容的问题。

我的 Formatter 已经被 GTNH 逆天的 spotless 调教的非常奇怪了，还请您麻烦自己重新格式化一下 🤣