### PR TITLE
[Optimization/Feature] Add `ColorRectAndBorderTexture` for combined rendering

### DIFF
--- a/common/src/main/java/com/lowdragmc/lowdraglib/client/shader/Shaders.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/client/shader/Shaders.java
@@ -38,6 +38,7 @@ public class Shaders {
 	public static Shader ROUND_BOX_F;
 	public static Shader PROGRESS_ROUND_BOX_F;
 	public static Shader FRAME_ROUND_BOX_F;
+	public static Shader FILLED_FRAME_ROUND_BOX_F;
 	public static Shader ROUND_LINE_F;
 
 	public static void init() {
@@ -50,6 +51,7 @@ public class Shaders {
 		ROUND_BOX_F = load(Shader.ShaderType.FRAGMENT, new ResourceLocation(LDLib.MOD_ID, "round_box"));
 		PROGRESS_ROUND_BOX_F = load(Shader.ShaderType.FRAGMENT, new ResourceLocation(LDLib.MOD_ID, "progress_round_box"));
 		FRAME_ROUND_BOX_F = load(Shader.ShaderType.FRAGMENT, new ResourceLocation(LDLib.MOD_ID, "frame_round_box"));
+		FILLED_FRAME_ROUND_BOX_F = load(Shader.ShaderType.FRAGMENT, new ResourceLocation(LDLib.MOD_ID, "filled_frame_round_box"));
 		ROUND_LINE_F = load(Shader.ShaderType.FRAGMENT, new ResourceLocation(LDLib.MOD_ID, "round_line"));
 	}
 

--- a/common/src/main/java/com/lowdragmc/lowdraglib/gui/texture/ColorRectAndBorderTexture.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/gui/texture/ColorRectAndBorderTexture.java
@@ -1,0 +1,133 @@
+package com.lowdragmc.lowdraglib.gui.texture;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.Configurable;
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
+import com.lowdragmc.lowdraglib.gui.editor.annotation.NumberColor;
+import com.lowdragmc.lowdraglib.gui.editor.annotation.NumberRange;
+import com.lowdragmc.lowdraglib.gui.util.DrawerHelper;
+import com.lowdragmc.lowdraglib.utils.Rect;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.GuiGraphics;
+import org.joml.Vector4f;
+
+import java.awt.*;
+
+@LDLRegister(name = "color_rect_and_border_texture", group = "texture")
+@Accessors(chain = true)
+public class ColorRectAndBorderTexture extends TransformTexture {
+
+    @Configurable
+    @NumberColor
+    @Setter
+    public int fillColor;
+
+    @Configurable
+    @NumberColor
+    @Setter
+    public int borderColor;
+
+    @Configurable
+    @Setter
+    @NumberRange(range = {0, 100}, wheel = 1)
+    public float borderThickness;
+
+    @Configurable
+    @Setter
+    @NumberRange(range = {0, Float.MAX_VALUE}, wheel = 1)
+    public float radiusLT;
+
+    @Configurable
+    @Setter
+    @NumberRange(range = {0, Float.MAX_VALUE}, wheel = 1)
+    public float radiusLB;
+
+    @Configurable
+    @Setter
+    @NumberRange(range = {0, Float.MAX_VALUE}, wheel = 1)
+    public float radiusRT;
+
+    @Configurable
+    @Setter
+    @NumberRange(range = {0, Float.MAX_VALUE}, wheel = 1)
+    public float radiusRB;
+
+    public ColorRectAndBorderTexture() {
+        this(0xFF2A2A36, 0xFF3D3D4E, 1.0f);
+    }
+
+    public ColorRectAndBorderTexture(int fillColor, int borderColor, float borderThickness) {
+        this.fillColor = fillColor;
+        this.borderColor = borderColor;
+        this.borderThickness = borderThickness;
+    }
+
+    public ColorRectAndBorderTexture(Color fillColor, Color borderColor, float borderThickness) {
+        this.fillColor = fillColor.getRGB();
+        this.borderColor = borderColor.getRGB();
+        this.borderThickness = borderThickness;
+    }
+
+    public ColorRectAndBorderTexture setRadius(float radius) {
+        this.radiusLB = radius;
+        this.radiusRT = radius;
+        this.radiusRB = radius;
+        this.radiusLT = radius;
+        return this;
+    }
+
+    public ColorRectAndBorderTexture setLeftRadius(float radius) {
+        this.radiusLB = radius;
+        this.radiusLT = radius;
+        return this;
+    }
+
+    public ColorRectAndBorderTexture setRightRadius(float radius) {
+        this.radiusRT = radius;
+        this.radiusRB = radius;
+        return this;
+    }
+
+    public ColorRectAndBorderTexture setTopRadius(float radius) {
+        this.radiusRT = radius;
+        this.radiusLT = radius;
+        return this;
+    }
+
+    public ColorRectAndBorderTexture setBottomRadius(float radius) {
+        this.radiusLB = radius;
+        this.radiusRB = radius;
+        return this;
+    }
+
+    @Environment(EnvType.CLIENT)
+    @Override
+    protected void drawInternal(GuiGraphics graphics, int mouseX, int mouseY, float x, float y, int width, int height) {
+        if (width <= 0 || height <= 0) return;
+
+        if (radiusLT > 0 || radiusLB > 0 || radiusRT > 0 || radiusRB > 0) {
+            float maxRadius = Math.min(width, height) / 2f;
+
+            DrawerHelper.drawFilledFrameRoundBox(
+                    graphics,
+                    Rect.ofRelative((int) x, width, (int) y, height),
+                    borderThickness,
+                    new Vector4f(
+                            Math.min(maxRadius, radiusRT),
+                            Math.min(maxRadius, radiusRB),
+                            Math.min(maxRadius, radiusLT),
+                            Math.min(maxRadius, radiusLB)
+                    ),
+                    fillColor,
+                    borderColor
+            );
+        } else {
+            DrawerHelper.drawSolidRect(graphics, (int) x, (int) y, width, height, fillColor);
+            if (borderThickness > 0) {
+                DrawerHelper.drawBorder(graphics, (int) x, (int) y, width, height, borderColor, (int) borderThickness);
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/lowdragmc/lowdraglib/gui/util/DrawerHelper.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/gui/util/DrawerHelper.java
@@ -49,6 +49,7 @@ public class DrawerHelper {
     public static ShaderProgram ROUND_BOX;
     public static ShaderProgram PROGRESS_ROUND_BOX;
     public static ShaderProgram FRAME_ROUND_BOX;
+    public static ShaderProgram FILLED_FRAME_ROUND_BOX;
     public static ShaderProgram ROUND_LINE;
 
     public static void init() {
@@ -62,6 +63,8 @@ public class DrawerHelper {
                 -> program.attach(Shaders.PROGRESS_ROUND_BOX_F).attach(Shaders.SCREEN_V));
         FRAME_ROUND_BOX = Util.make(new ShaderProgram(), program
                 -> program.attach(Shaders.FRAME_ROUND_BOX_F).attach(Shaders.SCREEN_V));
+        FILLED_FRAME_ROUND_BOX = Util.make(new ShaderProgram(), program
+                -> program.attach(Shaders.FILLED_FRAME_ROUND_BOX_F).attach(Shaders.SCREEN_V));
         ROUND_LINE = Util.make(new ShaderProgram(), program
                 -> program.attach(Shaders.ROUND_LINE_F).attach(Shaders.SCREEN_V));
     }
@@ -393,6 +396,33 @@ public class DrawerHelper {
             uniform.glUniform4F("RoundRadius2", radius2.x() * scale, radius2.y() * scale, radius2.z() * scale, radius2.w() * scale);
             uniform.glUniform1F("Thickness", thickness * scale);
             uniform.fillRGBAColor("Color", color);
+            uniform.glUniform1F("Blur", 2);
+        });
+
+        RenderSystem.enableBlend();
+        uploadScreenPosVertex();
+    }
+
+    public static void drawFilledFrameRoundBox(@Nonnull GuiGraphics graphics, Rect square, float thickness, Vector4f radius, int fillColor, int borderColor) {
+        FILLED_FRAME_ROUND_BOX.use(uniform -> {
+            DrawerHelper.updateScreenVshUniform(graphics, uniform);
+            uniform.glUniformMatrix4F("PoseStack", new Matrix4f());
+
+            var point1 = new Vector4f(square.left - 0.25f, square.up - 0.25f, 0, 1);
+            var point2 = new Vector4f(square.right - 0.25f, square.down - 0.25f, 0, 1);
+            var matrix = graphics.pose().last().pose();
+            point1.mul(matrix);
+            point2.mul(matrix);
+
+            var v1 = matrix.transform(new Vector4f(1, 1, 1, 1));
+            var v2 = matrix.transform(new Vector4f(0, 0, 0, 1));
+            var scale = v1.x - v2.x; // we just use the x scale
+
+            uniform.glUniform4F("SquareVertex", point1.x, point1.y, point2.x, point2.y);
+            uniform.glUniform4F("RoundRadius", radius.x() * scale, radius.y() * scale, radius.z() * scale, radius.w() * scale);
+            uniform.glUniform1F("Thickness", thickness);
+            uniform.fillRGBAColor("FillColor", fillColor);
+            uniform.fillRGBAColor("BorderColor", borderColor);
             uniform.glUniform1F("Blur", 2);
         });
 

--- a/common/src/main/java/com/lowdragmc/lowdraglib/test/ui/TestRender.java
+++ b/common/src/main/java/com/lowdragmc/lowdraglib/test/ui/TestRender.java
@@ -1,0 +1,26 @@
+package com.lowdragmc.lowdraglib.test.ui;
+
+import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegisterClient;
+import com.lowdragmc.lowdraglib.gui.modular.IUIHolder;
+import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
+import com.lowdragmc.lowdraglib.gui.texture.ColorRectAndBorderTexture;
+import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
+import lombok.NoArgsConstructor;
+import net.minecraft.world.entity.player.Player;
+
+@LDLRegisterClient(name="render", group = "ui_test")
+@NoArgsConstructor
+public class TestRender implements IUITest{
+
+    @Override
+    public ModularUI createUI(IUIHolder holder, Player entityPlayer) {
+        return new ModularUI(createUI2(), holder, entityPlayer);
+    }
+
+    public WidgetGroup createUI2() {
+        var root = new WidgetGroup();
+        root.setSize(100, 100);
+        root.setBackground(new ColorRectAndBorderTexture().setRadius(6));
+        return root;
+    }
+}

--- a/common/src/main/resources/assets/ldlib/lang/en_us.json
+++ b/common/src/main/resources/assets/ldlib/lang/en_us.json
@@ -204,6 +204,7 @@
   "ldlib.gui.editor.register.texture.text_texture": "Text Texture",
   "ldlib.gui.editor.register.texture.color_rect_texture": "Color Rect Texture",
   "ldlib.gui.editor.register.texture.color_border_texture": "Color Border Texture",
+  "ldlib.gui.editor.register.texture.color_rect_and_border_texture": "Color Rect & Border Texture",
   "ldlib.gui.editor.register.texture.animation_texture": "Animation Texture",
   "ldlib.gui.editor.register.texture.item_stack_texture": "Item Stack Texture",
   "ldlib.gui.editor.register.texture.shader_texture": "Shader Texture",

--- a/common/src/main/resources/assets/ldlib/lang/zh_cn.json
+++ b/common/src/main/resources/assets/ldlib/lang/zh_cn.json
@@ -181,6 +181,7 @@
     "ldlib.gui.editor.register.texture.text_texture": "文本纹理",
     "ldlib.gui.editor.register.texture.color_rect_texture": "彩色矩形纹理",
     "ldlib.gui.editor.register.texture.color_border_texture": "彩色边框纹理",
+    "ldlib.gui.editor.register.texture.color_rect_and_border_texture": "颜色矩形和边框纹理",
     "ldlib.gui.editor.register.texture.animation_texture": "动画纹理",
     "ldlib.gui.editor.register.texture.item_stack_texture": "物品纹理",
     "ldlib.gui.editor.register.texture.shader_texture": "着色器纹理",

--- a/common/src/main/resources/assets/ldlib/shaders/filled_frame_round_box.fsh
+++ b/common/src/main/resources/assets/ldlib/shaders/filled_frame_round_box.fsh
@@ -1,0 +1,43 @@
+#version 150
+
+in vec2 screenPos;
+in vec2 guiPos;
+in vec2 uv;
+
+out vec4 fragColor;
+
+uniform vec4 SquareVertex;
+uniform vec4 RoundRadius;
+uniform vec2 ScreenSize;
+uniform vec4 FillColor;
+uniform vec4 BorderColor;
+uniform float Thickness;
+uniform float Blur = 2.0;
+uniform float GuiScale;
+
+float sdRoundedBox(in vec2 p, in vec2 b, in vec4 r) {
+    r.xy = (p.x > 0.0) ? r.xy : r.zw;
+    r.x = (p.y > 0.0) ? r.x : r.y;
+    vec2 q = abs(p) - b + r.x;
+    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r.x;
+}
+
+void main() {
+    vec2 localUv = uv * ScreenSize / 2.0;
+    localUv.x += ScreenSize.x / 2.0 - SquareVertex.x * GuiScale - ((SquareVertex.z - SquareVertex.x) * GuiScale) / 2.0 - 2.0;
+    localUv.y -= ScreenSize.y / 2.0 - SquareVertex.y * GuiScale - ((SquareVertex.w - SquareVertex.y) * GuiScale) / 2.0 - 2.0;
+
+    vec2 extents = vec2((SquareVertex.z - SquareVertex.x) / 2.0, (SquareVertex.w - SquareVertex.y) / 2.0) * GuiScale;
+    vec4 radius = RoundRadius * GuiScale;
+
+    float d = sdRoundedBox(localUv, extents, radius);
+
+    float outerAlpha = smoothstep(Blur, 0.0, d);
+
+    float innerEdge = -Thickness * GuiScale;
+    float innerBlend = smoothstep(innerEdge + Blur, innerEdge, d);
+
+    vec4 finalColor = mix(FillColor, BorderColor, innerBlend);
+
+    fragColor = finalColor * outerAlpha;
+}


### PR DESCRIPTION
**Problem:**
Currently, rendering a standard UI panel with both a solid background and a border requires allocating and processing two separate textures (`ColorRectTexture` and `ColorBorderTexture`). This forces developers to use `IGuiTexture[]` arrays, creating unnecessary object allocations and adding overhead to the UI rendering hot path.

**Solution:**
Introduced `ColorRectAndBorderTexture` - a single `IGuiTexture` implementation that handles both the background fill and the border stroke in one pass.

P.s. I might have made an incorrect translation into Chinese, so please check it for accuracy.